### PR TITLE
docs: forge install to setup deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ You will need a copy of [Foundry](https://github.com/foundry-rs/foundry) install
 ```sh
 git clone https://github.com/transmissions11/goo-issuance.git
 cd goo-issuance
+forge install
 ```
 
 ### Run Tests


### PR DESCRIPTION
specify `forge install` on a fresh repo clone, or `forge test` will fail